### PR TITLE
fix: Updater fail

### DIFF
--- a/J-Runner/Classes/Upd.cs
+++ b/J-Runner/Classes/Upd.cs
@@ -231,7 +231,7 @@ namespace JRunner
                     return;
                 }
 
-                File.Move(@"JRunner.exe", @"JRunner.exe.old");
+                File.Move(@"" + System.AppDomain.CurrentDomain.FriendlyName, @"JRunner.exe.old");
 
                 // Unzip
                 using (ZipFile zip = ZipFile.Read(filename))

--- a/J-Runner/Forms/UpdateSuccess.cs
+++ b/J-Runner/Forms/UpdateSuccess.cs
@@ -14,12 +14,12 @@ namespace JRunner
 
         private void WizardCancelled(object sender, EventArgs e)
         {
-            Program.restart();
+            Application.Restart();
         }
 
         private void WizardFinished(object sender, EventArgs e)
         {
-            Program.restart();
+            Application.Restart();
         }
     }
 }


### PR DESCRIPTION
Fix updater to always rename exe regardless of name.