### PR TITLE
MTX tools output to the console

### DIFF
--- a/J-Runner/Classes/Mtx-Usb.cs
+++ b/J-Runner/Classes/Mtx-Usb.cs
@@ -113,11 +113,32 @@ namespace JRunner
                     else process.StartInfo.Arguments = "usb: -w" + size + " \"" + filename + "\"" + slArg;
                     process.StartInfo.UseShellExecute = false;
                     process.StartInfo.WorkingDirectory = Path.Combine(variables.rootfolder, "common/mtx-tools");
-                    process.StartInfo.CreateNoWindow = false;
+                    process.StartInfo.RedirectStandardOutput = true;
+                    process.StartInfo.CreateNoWindow = true;
+
+                    AutoResetEvent outputWaitHandle = new AutoResetEvent(false);
+                    process.OutputDataReceived += (sender, e) =>
+                    {
+                        if (e.Data == null)
+                        {
+                            outputWaitHandle.Set();
+                        }
+                        else
+                        {
+                            Console.WriteLine(e.Data);
+                        }
+                    };
 
                     NandX.InUse = true;
                     process.Start();
+                    process.BeginOutputReadLine();
                     process.WaitForExit();
+
+                    
+                    if (process.HasExited)
+                    {
+                        process.CancelOutputRead();
+                    }
 
                     inUseTimer.Enabled = false;
                     inUseCount = 0;
@@ -166,14 +187,35 @@ namespace JRunner
                     process.StartInfo.Arguments = "\"" + filename + "\"";
                     process.StartInfo.UseShellExecute = false;
                     process.StartInfo.WorkingDirectory = variables.rootfolder;
-                    process.StartInfo.CreateNoWindow = false;
+                    process.StartInfo.RedirectStandardOutput = true;
+                    process.StartInfo.CreateNoWindow = true;
+
+                    AutoResetEvent outputWaitHandle = new AutoResetEvent(false);
+                    process.OutputDataReceived += (sender, e) =>
+                    {
+                        if (e.Data == null)
+                        {
+                            outputWaitHandle.Set();
+                        }
+                        else
+                        {
+                            Console.WriteLine(e.Data.Replace("\b\b\b\b\b"," ["));
+                        }
+                    };
 
                     NandX.InUse = true;
                     process.Start();
+                    process.BeginOutputReadLine();
                     process.WaitForExit();
+
+                    if (process.HasExited)
+                    {
+                        process.CancelOutputRead();
+                    }
 
                     NandX.InUse = false;
                     Console.WriteLine("Xsvf: Completed!");
+                    Console.WriteLine("");
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
Hello. First of all, thank you for your great contribution to the console mods! 
J-Runner is a cool tool that includes everything you need to perform RGH in one window, but I've encountered some inconveniences.
**nandpro** and **xsvf** run in a separate window that closes automatically when they are finished. This prevents you from seeing the result of the operation. I have redirected the output to the J-Runners`s console, similar to the xebuild output.

Also, a few observations that are not related to this PR:
1. **xsvf.exe**, which is included in the J-Runner package, has version **1.0a**. And the archive from the original se7ensins thread has version **1.1f**. I haven't tested **1.0a**, but **1.1f** flashes 64 and 128 chips without any problems.
2. firmwares for MTX nand flasher **matrix_64a.HEX** and **matrix_128.hex** are identical. Both flash 64 and 128 chips(tested with xsvf.exe 1.1f). No need to include them both.
3. there is a way to install **libusb0** drivers without any problems with signatures on modern systems. There is a tool called **zadig** that signs and installs the driver for the selected VID/PID on the fly. Version **2.0.1.154** is the latest with **libusb0** **1.2,5.0**. There is also a cmd tool called **wdi-simple**, which I think can be used by J-Runner.

<details><summary>Screenshots</summary>

![Screenshot 2023-10-15 161157](https://github.com/Octal450/J-Runner-with-Extras/assets/1225948/6c6205b5-8bc8-4606-80b5-0a8bca75868e)

![Screenshot 2023-10-15 161223](https://github.com/Octal450/J-Runner-with-Extras/assets/1225948/6cae9e8c-2dc5-4926-af68-d177449b9cd1)

![Screenshot 2023-10-15 161250](https://github.com/Octal450/J-Runner-with-Extras/assets/1225948/97a55957-d578-4471-bd12-a403ab1b016b)


</details>