### PR TITLE
NAND Alignment for Corona 4GB 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -250,3 +250,4 @@ paket-files/
 # JetBrains Rider
 .idea/
 *.sln.iml
+/.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -250,4 +250,3 @@ paket-files/
 # JetBrains Rider
 .idea/
 *.sln.iml
-/.vscode

--- a/J-Runner/Classes/CpuKeyGen.cs
+++ b/J-Runner/Classes/CpuKeyGen.cs
@@ -6,110 +6,106 @@ namespace JRunner
 {
     public static class CpuKeyGen
     {
-        static int hamming = 0;
-        static byte[] bytes = new byte[16];
-        static byte[] generatedKey;
-
+   
+        private static readonly int[] PopCountTable = new int[256]
+        {
+            0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4,
+            1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,
+            1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,
+            2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
+            1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,
+            2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
+            2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
+            3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7,
+            1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,
+            2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
+            2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
+            3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7,
+            2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
+            3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7,
+            3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7,
+            4, 5, 5, 6, 5, 6, 6, 7, 5, 6, 6, 7, 6, 7, 7, 8
+        };
+        private static int PopCount(byte value)
+        {
+            return PopCountTable[value];
+        }
         public static string GenerateKey()
         {
-            var csprng = new RNGCryptoServiceProvider();
-            csprng.GetNonZeroBytes(bytes);
-            while (!VerifyKey(bytes))
+            var rng = RandomNumberGenerator.Create();
+            byte[] key = new byte[16];
+            byte[] generatedKey;
+
+            do
             {
-                csprng.GetNonZeroBytes(bytes);
+                rng.GetNonZeroBytes(key);
             }
+            while (!VerifyKey(key, out generatedKey));
+
             return BitConverter.ToString(generatedKey).Replace("-", string.Empty);
         }
 
-        private static bool VerifyKey(byte[] key)
+        private static bool VerifyKey(byte[] key, out byte[] generatedKey)
         {
-            byte[] hammingArray = new byte[13];
+            generatedKey = null;
 
-            //CB 74 FC A5 5F 12 64 01 F6 B2 5B 84 2D 
-            //A6 C2 97 cut 
-
-            // C    B    7    4
-            //1100 1011 0111 0100
-            Buffer.BlockCopy(key, 0, hammingArray, 0, 13);
-            BitArray bitArray = new BitArray(hammingArray); //array of true/false for 0/1 ez
-
-
-            foreach (bool s in bitArray)
+            // Calculate Hamming weight using efficient bit counting
+            int hamming = 0;
+            for (int i = 0; i < 13; i++)
             {
-                if (s) hamming++; //if true, increase hamming
-            }
-            //if hamming is 53 already, great. make sure both checks below fail.
-
-            //Don't pull your hair out like I did for a bit, 13 is A6 in the cut off portion. I forgot about 0 hehe
-            //1010 0110 in binary 
-            if (key[13].getBit(0))
-            {    //shift 0, get t/f
-                hamming++;
+                hamming += PopCount(key[i]);
             }
 
-            if (key[13].getBit(1)) //shift to left one, get t/f. add 
-            {
-                hamming++;
-            }
+            // Check bits 0 and 1 of byte 13 using bitwise operations
+            hamming += (key[13] & 0b00000001) + ((key[13] & 0b00000010) >> 1);
 
-
-            if (hamming != 53)
-            {
-                hamming = 0;
-                return false;
-            }
+            if (hamming != 53) return false;
 
             generatedKey = CalculateCPUKeyECD(key);
-
-            Array.Copy(generatedKey, key, 16);
-            if (!ByteArrayCompare(key, generatedKey)) return false;
-            else return true;
-        }
-
-        public static bool ByteArrayCompare(byte[] a1, byte[] a2, int size = 0)
-        {
-            if (a1 == null || a2 == null) return false;
-            if (size == 0)
-            {
-                size = a1.Length;
-                if (a1.Length != a2.Length)
-                    return false;
-            }
-
-            for (int i = 0; i < size; i++)
-                if (a1[i] != a2[i])
-                    return false;
-
             return true;
         }
 
         private static byte[] CalculateCPUKeyECD(byte[] key)
         {
             byte[] ecd = new byte[0x10];
-            Buffer.BlockCopy(key, 0, ecd, 0, 0x10); //src, offsetstart, dst, offsetstart, len
+            Buffer.BlockCopy(key, 0, ecd, 0, 0x10);
 
             uint acc1 = 0, acc2 = 0;
 
-            for (var cnt = 0; cnt < 0x80; cnt++, acc1 >>= 1)
+            // Process bits 0 to 105 (0x6A iterations)
+            for (int cnt = 0; cnt < 0x6A; cnt++)
             {
+                int byteIndex = cnt >> 3;
+                int bitIndex = cnt & 7;
+                byte b = ecd[byteIndex];
+                uint bit = (uint)((b >> bitIndex) & 1);
 
-                var bTmp = ecd[cnt >> 3];
-                var dwTmp = (uint)((bTmp >> (cnt & 7)) & 1);
-                if (cnt < 0x6A)
-                {
-                    acc1 = dwTmp ^ acc1;
-                    if ((acc1 & 1) > 0)
-                        acc1 = acc1 ^ 0x360325;
-                    acc2 = dwTmp ^ acc2;
-                }
-                else if (cnt < 0x7F)
-                {
-                    if (dwTmp != (acc1 & 1))
-                        ecd[(cnt >> 3)] = (byte)((1 << (cnt & 7)) ^ (bTmp & 0xFF));
-                    acc2 = (acc1 & 1) ^ acc2;
-                }
-                else if (dwTmp != acc2)
-                    ecd[0xF] = (byte)((0x80 ^ bTmp) & 0xFF);
+                acc1 ^= bit;
+                acc1 ^= (acc1 & 1) * 0x360325U;
+                acc2 ^= bit;
+
+                acc1 >>= 1;
+            }
+
+            // Process bits 106 to 126 (21 iterations)
+            for (int cnt = 0x6A; cnt < 0x7F; cnt++)
+            {
+                int byteIndex = cnt >> 3;
+                int bitIndex = cnt & 7;
+                byte b = ecd[byteIndex];
+                uint bit = (uint)((b >> bitIndex) & 1);
+
+                uint lsb = acc1 & 1;
+                ecd[byteIndex] ^= (byte)(((bit ^ lsb) & 1) << bitIndex);
+                acc2 ^= lsb;
+
+                acc1 >>= 1;
+            }
+
+            // Process bit 127
+            {
+                uint bit = (uint)((ecd[15] >> 7) & 1);
+                ecd[15] ^= (byte)(((bit ^ (acc2 & 1)) & 1) << 7);
             }
 
             return ecd;

--- a/J-Runner/MainForm.Designer.cs
+++ b/J-Runner/MainForm.Designer.cs
@@ -166,6 +166,8 @@ namespace JRunner
             this.jRPBLToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.updateJRPToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.keyDatabaseToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.nANDAlignmentToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.gB16MBToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.groupBox8.SuspendLayout();
             this.getCpuKeyMenu.SuspendLayout();
             this.showWorkingFolderMenu.SuspendLayout();
@@ -1175,6 +1177,7 @@ namespace JRunner
             this.extractFilesToolStripMenuItem,
             this.createDonorToolStripMenuItem,
             this.createSafeDualImageToolStripMenuItem,
+            this.nANDAlignmentToolStripMenuItem,
             this.decryptKeyvaultToolStripMenuItem,
             this.toolStripMenuItem11,
             this.loadGlitch2XeLLToolStripMenuItem,
@@ -1345,6 +1348,21 @@ namespace JRunner
             this.keyDatabaseToolStripMenuItem.Size = new System.Drawing.Size(105, 20);
             this.keyDatabaseToolStripMenuItem.Text = "Key Database";
             this.keyDatabaseToolStripMenuItem.Click += new System.EventHandler(this.keyDatabaseToolStripMenuItem_Click);
+            // 
+            // nANDAlignmentToolStripMenuItem
+            // 
+            this.nANDAlignmentToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.gB16MBToolStripMenuItem});
+            this.nANDAlignmentToolStripMenuItem.Name = "nANDAlignmentToolStripMenuItem";
+            this.nANDAlignmentToolStripMenuItem.Size = new System.Drawing.Size(213, 22);
+            this.nANDAlignmentToolStripMenuItem.Text = "NAND Alignment";
+            // 
+            // gB16MBToolStripMenuItem
+            // 
+            this.gB16MBToolStripMenuItem.Name = "gB16MBToolStripMenuItem";
+            this.gB16MBToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.gB16MBToolStripMenuItem.Text = "4GB -> 16MB";
+            this.gB16MBToolStripMenuItem.Click += new System.EventHandler(this.gB16MBToolStripMenuItem_Click);
             // 
             // MainForm
             // 
@@ -1532,5 +1550,7 @@ namespace JRunner
         private ToolStripStatusLabel BlankSpace2;
         private ToolStripStatusLabel CopiedToClipboard;
         private ToolStripMenuItem createSafeDualImageToolStripMenuItem;
+        private ToolStripMenuItem nANDAlignmentToolStripMenuItem;
+        private ToolStripMenuItem gB16MBToolStripMenuItem;
     }
 }

--- a/J-Runner/MainForm.cs
+++ b/J-Runner/MainForm.cs
@@ -40,7 +40,7 @@ namespace JRunner
             XFLASHER_EMMC = 4,
             PICOFLASHER = 5,
         }
-		
+
         public static TextWriter _writer = null;
         public static MainForm mainForm;
         private IDeviceNotifier devNotifier;
@@ -167,11 +167,11 @@ namespace JRunner
             cleanupThread.Start();
 
             printstartuptext(true);
-            
+
             new Thread(check_dash).Start();
 
             deviceinit();
-            
+
             try
             {
                 if (File.Exists(xflasher.svfPath)) File.Delete(xflasher.svfPath);
@@ -663,7 +663,7 @@ namespace JRunner
         }
 
         #region Nand
-        
+
         public Nand.PrivateN getNand()
         {
             return nand;
@@ -694,7 +694,7 @@ namespace JRunner
                 {
                     if (device == DEVICE.PICOFLASHER)
                     {
-                        picoflasher.Read(1, (uint) startblock, (uint) (startblock + length)); // TODO: respect filename
+                        picoflasher.Read(1, (uint)startblock, (uint)(startblock + length)); // TODO: respect filename
                     }
                     else if (device == DEVICE.XFLASHER_SPI)
                     {
@@ -870,7 +870,7 @@ namespace JRunner
             }
             nandTimingFunctionsExecute(function, filename, size, startblock, length, recalcEcc);
         }
-                
+
         private void programTimingFile(string filex)
         {
             string file = "";
@@ -895,7 +895,7 @@ namespace JRunner
                         MessageBox.Show("PicoFlasher can't to program timing", "Can't", MessageBoxButtons.OK, MessageBoxIcon.Error);
                         return;
                     }
-                    else if(device == DEVICE.XFLASHER_SPI)
+                    else if (device == DEVICE.XFLASHER_SPI)
                     {
                         xflasher.flashSvf(file);
                     }
@@ -923,7 +923,7 @@ namespace JRunner
                 }
             }
         }
-        
+
         private NandX.Errors getmbtype()
         {
             Console.WriteLine("Checking Console...");
@@ -1013,7 +1013,7 @@ namespace JRunner
                             xPanel.setMBname(variables.ctype.Text);
                         }
                     }
-                    else if (temp >= 4558 && temp <= 4580) 
+                    else if (temp >= 4558 && temp <= 4580)
                     {
                         if (flashconfig == "01198030")
                         {
@@ -1904,7 +1904,7 @@ namespace JRunner
                 {
                     variables.cpukey = parsecpukey(cpufile);
                 }
-                
+
                 if (variables.cpukey.Length != 32 || !objAlphaPattern.IsMatch(variables.cpukey)) variables.cpukey = "";
 
                 bool foundKey = !string.IsNullOrEmpty(variables.cpukey);
@@ -1913,7 +1913,7 @@ namespace JRunner
                 if (!foundKey)
                 {
                     long filenameKvCrc = Nand.Nand.kvcrc(variables.filename1, true);
-                    
+
                     if (variables.debugMode) Console.WriteLine("KV CRC: {0:X}", filenameKvCrc);
                     if (variables.debugMode) Console.WriteLine("Searching Registry Entrys");
                     try
@@ -1993,7 +1993,7 @@ namespace JRunner
                         else Console.WriteLine("Wrong CPU Key");
                     }
                 }
-                
+
                 nandInfo.setNand(nand);
                 updateProgress((progressBar.Maximum / 4) * 3); // 75%
 
@@ -2065,9 +2065,9 @@ namespace JRunner
                         fs.Read(patchesByte, 0, 0x5B230); // 0x8FFD0 - 0xEB200
                         patchesByte = Nand.Nand.unecc(patchesByte);
                     }
-                    
+
                     byte[] patches = new byte[0x4000];
-                    
+
                     if (nand.bigblock)
                     {
                         for (int i = 0; i < patches.Length; i++)
@@ -2086,20 +2086,20 @@ namespace JRunner
                     // Needs to be run twice for JTAG checking, no reliable way to check which it is
                     PatchParser patchParser = new PatchParser(patches);
                     bool patchResult = patchParser.parseAll();
-                
+
                     if (!patchResult)
                     {
                         patches = new byte[0x4000];
-                
+
                         for (int i = 0; i < patches.Length; i++)
                         {
                             patches[i] = patchesByte[0x59F0 + i]; // JTAG all sizes, 0x913F0
                         }
-                
+
                         patchParser.enterData(patches);
                         patchParser.parseAll();
                     }
-                    
+
                 }
                 catch
                 {
@@ -4324,7 +4324,7 @@ namespace JRunner
                         //PicoFlasherToolStripMenuItem.Visible = false;
                         device = DEVICE.NO_DEVICE;
                     }
-                    else if(e.Device.IdVendor == 0x11d4 && e.Device.IdProduct == 0x8334)
+                    else if (e.Device.IdVendor == 0x11d4 && e.Device.IdProduct == 0x8334)
                     {
                         HID.BootloaderDetected = false;
                         if (!DemoN.DemonDetected) nTools.setImage(null);
@@ -4895,7 +4895,8 @@ namespace JRunner
         {
             if (mode > 0)
             {
-                ProgressLabel.BeginInvoke(new Action(() => {
+                ProgressLabel.BeginInvoke(new Action(() =>
+                {
                     if (mode == 3) ProgressLabel.Text = "Erasing";
                     else if (mode == 2) ProgressLabel.Text = "Writing";
                     else if (mode == 1) ProgressLabel.Text = "Reading";
@@ -4909,7 +4910,8 @@ namespace JRunner
             else if (mode == -1)
             {
                 ProgressLabel.BeginInvoke(new Action(() => ProgressLabel.Text = "Progress"));
-                progressBar.BeginInvoke(new Action(() => {
+                progressBar.BeginInvoke(new Action(() =>
+                {
                     progressBar.Style = ProgressBarStyle.Blocks;
                     progressBar.Value = progressBar.Minimum;
                 }));
@@ -4918,7 +4920,8 @@ namespace JRunner
             else
             {
                 ProgressLabel.BeginInvoke(new Action(() => ProgressLabel.Text = "Progress"));
-                progressBar.BeginInvoke(new Action(() => {
+                progressBar.BeginInvoke(new Action(() =>
+                {
                     progressBar.Style = ProgressBarStyle.Blocks;
                     progressBar.Value = progressBar.Maximum;
                 }));
@@ -4959,7 +4962,8 @@ namespace JRunner
         {
             if (mode > 0)
             {
-                ProgressLabel.BeginInvoke(new Action(() => {
+                ProgressLabel.BeginInvoke(new Action(() =>
+                {
                     if (mode == 3) ProgressLabel.Text = "Erasing";
                     else if (mode == 2) ProgressLabel.Text = "Writing";
                     else if (mode == 1) ProgressLabel.Text = "Reading";
@@ -4973,7 +4977,8 @@ namespace JRunner
             else if (mode == -1)
             {
                 ProgressLabel.BeginInvoke(new Action(() => { ProgressLabel.Text = "Progress"; }));
-                progressBar.BeginInvoke(new Action(() => {
+                progressBar.BeginInvoke(new Action(() =>
+                {
                     progressBar.Style = ProgressBarStyle.Blocks;
                     progressBar.Value = progressBar.Minimum;
                 }));
@@ -4982,7 +4987,8 @@ namespace JRunner
             else
             {
                 ProgressLabel.BeginInvoke(new Action(() => { ProgressLabel.Text = "Progress"; }));
-                progressBar.BeginInvoke(new Action(() => {
+                progressBar.BeginInvoke(new Action(() =>
+                {
                     progressBar.Style = ProgressBarStyle.Blocks;
                     progressBar.Value = progressBar.Maximum;
                 }));
@@ -5064,5 +5070,48 @@ namespace JRunner
         }
 
         #endregion
+
+        private void gB16MBToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            
+
+            if (variables.filename1 == "")
+            {
+
+                MessageBox.Show("Are you serious?", "Can't", MessageBoxButtons.OK, MessageBoxIcon.Error);
+
+            }
+            else
+            {
+                FileStream fs = new FileStream(variables.filename1, FileMode.Open);
+                byte[] noecc_data = new byte[0x01000000];
+                byte[] ecc_data = new byte[0x01080000];
+                fs.Position = 0;
+
+                switch (variables.ctype.Text)
+                {
+                    case "Corona 4GB":
+                        fs.Read(noecc_data, 0, 0x01000000);
+
+                        //byte array of first 0x01000000 in 4GB Corona NAND, add ecc true, block start 0, layout 1.
+                        this.BeginInvoke(new Action(() =>
+
+                        ecc_data = Nand.Nand.addecc_v2(noecc_data, true, 0, 1)
+                        
+                        ));
+                        Console.WriteLine("Aligning NAND to 16MB. Please do not interact with JRunner");
+                        
+                        File.WriteAllBytes(variables.filename1.Substring(0, variables.filename1.Length - 4) + "_aligned.bin", ecc_data);
+
+                        fs.Close();
+                        break;
+                    default:
+                        break;
+
+                }
+            }
+        
+        }
+
     }
 }

--- a/J-Runner/MainForm.resx
+++ b/J-Runner/MainForm.resx
@@ -120,9 +120,6 @@
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>917, 17</value>
   </metadata>
-  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>917, 17</value>
-  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="btnIPGetCPU.BtnImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>


### PR DESCRIPTION
Optimize for speed and readability of code for CPU key generation

Allows you to create a 16MB NAND out of a 48MB Corona dump without CPU key so you can retain all retail functionality
