### PR TITLE
UI Updates for Winchester board type

### DIFF
--- a/J-Runner/Forms/ConsoleSelect.Designer.cs
+++ b/J-Runner/Forms/ConsoleSelect.Designer.cs
@@ -254,12 +254,15 @@ namespace JRunner
             this.Controls.Add(this.phatBox);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.KeyPreview = true;
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "ConsoleSelect";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Select Console Type";
             this.Load += new System.EventHandler(this.ConsoleSelect_Load);
+            this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.ConsoleSelect_KeyDown);
+            this.KeyUp += new System.Windows.Forms.KeyEventHandler(this.ConsoleSelect_KeyUp);
             this.phatBox.ResumeLayout(false);
             this.slimBox.ResumeLayout(false);
             this.AdvancedBox.ResumeLayout(false);

--- a/J-Runner/Forms/ConsoleSelect.cs
+++ b/J-Runner/Forms/ConsoleSelect.cs
@@ -246,5 +246,31 @@ namespace JRunner
                 AdvancedBox.Visible = false;
             }
         }
+
+        private void renameCoronaButtons()
+        {
+            if ((ModifierKeys & Keys.Control) == Keys.Control && (ModifierKeys & Keys.Shift) == Keys.Shift)
+            {
+                btnCorona.Text = "Winchester 16MB";
+                btnCorona4g.Text = "Winchester 4GB";
+                btnCoronaBb.Text = "Winchester BB";
+            }
+            else
+            {
+                btnCorona.Text = "Corona 16MB";
+                btnCorona4g.Text = "Corona 4GB";
+                btnCoronaBb.Text = "Corona BB";
+            }
+        }
+
+        private void ConsoleSelect_KeyDown(object sender, KeyEventArgs e)
+        {
+            renameCoronaButtons();
+        }
+
+        private void ConsoleSelect_KeyUp(object sender, KeyEventArgs e)
+        {
+            renameCoronaButtons();
+        }
     }
 }

--- a/J-Runner/Panels/XeBuildPanel.cs
+++ b/J-Runner/Panels/XeBuildPanel.cs
@@ -480,7 +480,7 @@ namespace JRunner.Panels
             }
             else
             {
-                if (board.Contains("Winchester") || board.Contains("Corona") || board.Contains("Trinity") || board.Contains("None")) rbtnGlitch2m.Enabled = true;
+                if (board.Contains("Corona") || board.Contains("Trinity") || board.Contains("None")) rbtnGlitch2m.Enabled = true;
                 else rbtnGlitch2m.Enabled = rbtnGlitch2m.Checked = false;
             }
         }

--- a/J-Runner/Panels/XeBuildPanel.cs
+++ b/J-Runner/Panels/XeBuildPanel.cs
@@ -480,7 +480,7 @@ namespace JRunner.Panels
             }
             else
             {
-                if (board.Contains("Corona") || board.Contains("Trinity") || board.Contains("None")) rbtnGlitch2m.Enabled = true;
+                if (board.Contains("Winchester") || board.Contains("Corona") || board.Contains("Trinity") || board.Contains("None")) rbtnGlitch2m.Enabled = true;
                 else rbtnGlitch2m.Enabled = rbtnGlitch2m.Checked = false;
             }
         }

--- a/J-Runner/Panels/XeBuildPanel.cs
+++ b/J-Runner/Panels/XeBuildPanel.cs
@@ -467,9 +467,8 @@ namespace JRunner.Panels
         private void checkGlitch2(string board)
         {
             if (board == null) board = "None";
-            //if (board.Contains("Xenon")) rbtnGlitch2.Enabled = rbtnGlitch2.Checked = false;
-            //else
-            rbtnGlitch2.Enabled = true;
+            if (board.Contains("Winchester")) rbtnGlitch2.Enabled = rbtnGlitch2.Checked = false;
+            else rbtnGlitch2.Enabled = true;
         }
 
         private void checkGlitch2m(string board)


### PR DESCRIPTION
- xeBuildPanel: Disable glitch2 option when Winchester console type is selected, since they're currently unglitchable
- ConsoleSelect: Re-name the `Corona` buttons to their Winchester equivalents when the ctrl+shift secret key combo is pressed

e.g.

![image](https://github.com/user-attachments/assets/810f2c0e-353b-4df7-8ac0-4c0b485356dd)

