### PR TITLE
Tolerate console log save errors when closing J-Runner

### DIFF
--- a/J-Runner/MainForm.cs
+++ b/J-Runner/MainForm.cs
@@ -409,7 +409,7 @@ namespace JRunner
 
                     try
                     {
-                        file += "." + DateTime.Now.ToString("yyyyMMdd");
+                        file = Path.Combine(variables.rootfolder, "Console_" + DateTime.Now.ToString("yyyyMMdd") + ".log");
                         File.AppendAllText(file, "\n" + txtConsole.Text);
                     }
                     catch

--- a/J-Runner/MainForm.cs
+++ b/J-Runner/MainForm.cs
@@ -405,17 +405,17 @@ namespace JRunner
                     // won't be able to close. Append today's date
                     // to the file path and reattempt the write.
                     Console.WriteLine("Couldn't write console log to " + file);
-                    Console.WriteLine(e.ToString() + " " + e.Message);
+                    Console.WriteLine(e.GetType().ToString() + " " + e.Message);
 
                     try
                     {
-                        file += DateTime.Now.ToString("yyyyMMdd");
+                        file += "." + DateTime.Now.ToString("yyyyMMdd");
                         File.AppendAllText(file, "\n" + txtConsole.Text);
                     }
                     catch
                     {
                         // If we failed at the reattempt, prompt the user if they wish to close without saving.
-                        DialogResult closingDialogResult = MessageBox.Show("Encountered " + e.ToString() + ". Unable to save console log. Close J-Runner?", "Error", MessageBoxButtons.YesNo, MessageBoxIcon.Error);
+                        DialogResult closingDialogResult = MessageBox.Show("Encountered " + e.GetType().ToString() + " writing to " + file + ". \n\nUnable to save console log. Close J-Runner?", "Error", MessageBoxButtons.YesNo, MessageBoxIcon.Error);
 
                         // If the user selected "no", re-throw the original exception
                         if (closingDialogResult == DialogResult.No)

--- a/J-Runner/MainForm.cs
+++ b/J-Runner/MainForm.cs
@@ -384,13 +384,51 @@ namespace JRunner
             }
 
             savesettings();
-            saveToLog();
+            saveToLog(true);
         }
 
-        private void saveToLog()
+        private void saveToLog(bool bFormClosing)
         {
             string file = Path.Combine(variables.rootfolder, "Console.log");
-            File.AppendAllText(file, "\n" + txtConsole.Text);
+
+            try
+            {
+                File.AppendAllText(file, "\n" + txtConsole.Text);
+            }
+            catch (Exception e)
+            {
+                if (bFormClosing)
+                {
+                    // If we failed to write to the normal log file,
+                    // and the main form is closing, try an alternate.
+                    // Tolerate exceptions, otherwise the main form
+                    // won't be able to close. Append today's date
+                    // to the file path and reattempt the write.
+                    Console.WriteLine("Couldn't write console log to " + file);
+                    Console.WriteLine(e.ToString() + " " + e.Message);
+
+                    try
+                    {
+                        file += DateTime.Now.ToString("yyyyMMdd");
+                        File.AppendAllText(file, "\n" + txtConsole.Text);
+                    }
+                    catch
+                    {
+                        // If we failed at the reattempt, prompt the user if they wish to close without saving.
+                        DialogResult closingDialogResult = MessageBox.Show("Encountered " + e.ToString() + ". Unable to save console log. Close J-Runner?", "Error", MessageBoxButtons.YesNo, MessageBoxIcon.Error);
+
+                        // If the user selected "no", re-throw the original exception
+                        if (closingDialogResult == DialogResult.No)
+                        {
+                            throw e;
+                        }
+                    }
+                }
+                else
+                {
+                    throw e;
+                }
+            }
         }
 
         #endregion
@@ -1852,7 +1890,7 @@ namespace JRunner
 
             if (!partial)
             {
-                saveToLog();
+                saveToLog(false);
                 txtConsole.Text = "";
                 printstartuptext();
             }


### PR DESCRIPTION
Recently encountered an issue where the console log file couldn't be written when closing J-Runner, preventing the main form from closing without ending the J-Runner process:

![image](https://github.com/user-attachments/assets/ca50a61f-f8d5-40b7-b0ef-908d9d9c224e)

This PR adds some additional error handling when the main form is closing by attempting to save to an alternate log file. If THAT fails, the user is prompted whether they wish to exit.

Tested that this behaves as expected by injecting exceptions in the two `try` blocks.